### PR TITLE
[MetaC]: Depend on XMLParser v3 to Track Major Version Only

### DIFF
--- a/src/BaselineOfSoup.package/BaselineOfSoup.class/instance/baseline..st
+++ b/src/BaselineOfSoup.package/BaselineOfSoup.class/instance/baseline..st
@@ -29,7 +29,7 @@ baseline: spec
 		
 	spec for: #notGToolkit do: [
 		spec baseline: 'XMLParser' with: [
-			spec repository: 'github://pharo-contributions/XML-XMLParser:v3.x.x' ].
+			spec repository: 'github://pharo-contributions/XML-XMLParser:v3' ].
 		spec package: 'Soup-Core' with: [
 			spec requires: #('XMLParser' ). ] ].
 


### PR DESCRIPTION
Using ba-st naming convention omitting `.x`'s