### PR TITLE
[Bug]: Decode WideStrings More Gracefully

### DIFF
--- a/src/Soup-Core.package/SoupDecoder.class/instance/decodeFrom..st
+++ b/src/Soup-Core.package/SoupDecoder.class/instance/decodeFrom..st
@@ -5,6 +5,8 @@ decodeFrom: encodingName
 	converter ifNil: [self error: 'No text converter for ' , encodingName].
 	(self shouldConvertSmartQuotes: encodingName) 
 		ifTrue: [xmlData := self convertSmartQuotes: xmlData].
-	^ [converter decodeBytes: xmlData asByteArray]
+	^ [ | bytes |
+		bytes := converter encodeString: xmlData.
+		bytes asString ]
 		on: Error
 		do: [:e | nil]

--- a/src/Soup-Core.package/monticello.meta/categories.st
+++ b/src/Soup-Core.package/monticello.meta/categories.st
@@ -1,4 +1,1 @@
-SystemOrganization addCategory: #'Soup-Core'!
-SystemOrganization addCategory: #'Soup-Core-Base'!
-SystemOrganization addCategory: #'Soup-Core-Parser'!
-SystemOrganization addCategory: #'Soup-Core-TextConversion'!
+self packageOrganizer ensurePackage: #'Soup-Core' withTags: #(#Base #Parser #TextConversion)!

--- a/src/Soup-Tests-Core.package/SoupDecoderTest.class/instance/testWideString.st
+++ b/src/Soup-Tests-Core.package/SoupDecoderTest.class/instance/testWideString.st
@@ -1,0 +1,8 @@
+as yet unclassified
+testWideString
+	"Handle non-ASCII characters somewhat gracefully. Previous implementation was naively converting WideString input into bytes, resulting in many null values interleaved with actual characters"
+	
+	| decoder |
+	decoder := SoupDecoder new.
+	decoder string: '“Hello” World'.
+	self assert: decoder decode equals: 'âHelloâ World'

--- a/src/Soup-Tests-Core.package/monticello.meta/categories.st
+++ b/src/Soup-Tests-Core.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: #'Soup-Tests-Core'!
+self packageOrganizer ensurePackage: #'Soup-Tests-Core' withTags: #()!


### PR DESCRIPTION
Previously, passing a WideString to Soup would naively convert to bytes assuming an ASCII ByteString, resulting in many null values interleaved with actual characters

Old result:
<img width="538" height="37" alt="Screenshot 2026-02-05 at 3 04 24 PM" src="https://github.com/user-attachments/assets/e41dc67c-31b4-462f-a264-932bb77aab8c" />
New result:
<img width="169" height="37" alt="Screenshot 2026-02-05 at 3 05 27 PM" src="https://github.com/user-attachments/assets/5d2c0dbd-acc7-41a5-a426-a008248a821a" />

But the big payoff is that the old result could result in Soup parsing a hierarchy of HTML tags as one giant SoupString, which is prevented with the fix.

- Includes a test that failed previously and passes now
- Future work might correctly handle the charset and/or include non-ASCII smart quote escaping